### PR TITLE
Ignore `---` at beginning of line

### DIFF
--- a/scripts/karma.coffee
+++ b/scripts/karma.coffee
@@ -193,6 +193,7 @@ module.exports = (robot) ->
     neg_grouped_regex = ///
       (                               # Group 1.
         (                             # Group 2.
+          \w                          # Don't match a name on the previous line (fixes code blocks)
           (                           # Group 3.
             @(\S+[^+:\s])\s           # Group 4. Someone's name followed by a space
             |(\S+[^+:\s])             # Group 5. A single word not followed by a space, :, or +


### PR DESCRIPTION
Possible solution to accidental karma changes in code blocks #4

A tokenizer/parser would be better, but with a bit of testing, this seems to work too.

Tested with:

    ```
    Notice: /Stage[main]/Profile::Gitconfig/Concat[gitconfig]/File[/etc/gitconfig.d/puppet]/content:
    --- /etc/gitconfig.d/puppet     2022-04-25 14:46:24.782974442 -0400   <<NOT MATCHED
    +++ /tmp/puppet-file20220601-4027898-lrhuz8     2022-06-01 08:39:28.822038960 -0400
    @@ -9,4 +9,5 @@
             directory = /var/www/sites/www.example.com/cms
    +        directory = /var/www/sites/www.example.org/cms
    ```
    
    test--  <<MATCHED
    Remove karma @something--  <<MATCHED
