### PR TITLE
Stop lowering ```'s karma with YAML code snippets

### DIFF
--- a/scripts/karma.coffee
+++ b/scripts/karma.coffee
@@ -24,6 +24,7 @@ blacklist = [
   /^(lib)?stdc$/
   /-{2,}/
   /^[rwx-]+$/
+  /```/
 ]
 
 class Karma

--- a/scripts/karma.coffee
+++ b/scripts/karma.coffee
@@ -20,7 +20,7 @@
 #
 # Category: social
 
-blacklist = [
+ignorelist = [
   /^(lib)?stdc$/
   /-{2,}/
   /^[rwx-]+$/
@@ -111,7 +111,7 @@ mention_name = (robot, user) ->
   robot.brain.data.users[user.id].slack.profile.display_name
 
 filtered = (subject) ->
-    blacklist.some (re) ->
+    ignorelist.some (re) ->
       subject.match re
 
 normalizeSubject = (subject) ->


### PR DESCRIPTION
When sending YAML code snippets, "```" take a dive:

![Screenshot 2022-10-06 at 10-05-29 Slack puppet Puppet Community](https://user-images.githubusercontent.com/148721/194408162-e3154380-e194-4af9-add7-f38724f7b9c0.png)

This should prevent this from happening.