### PR TITLE
clean up local testing instructions a bit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 k8s/secret.yaml
+env.dev
 

--- a/README.md
+++ b/README.md
@@ -24,10 +24,16 @@ You can also *write* a custom script.
 ### Building and testing
 
 * Build the image with `rake docker:build`.
+* You'll need some environment variables in a file named `env.dev`. You'll need to
+  generate your own secrets:
+    * `HUBOT_SLACK_TOKEN=<...>`
+    * `SLACK_SIGNING_SECRET=<...>`
+    * `GOOGLE_CALENDAR_APIKEY=<...>`
+    * `HUBOT_BRAIN_DIR=/home/hubot/state`
 * Run the bot locally for testing with `rake docker:run`. This will drop you into
   a shell bot simulator where you can "direct message" with the bot.
 * If you need filesystem access, you can run the image directly:
-    * `docker run -it puppetlabs/bunsen /bin/sh`
+    * `docker run --env-file env.dev -it puppetlabs/bunsen /bin/sh`
     * Start the shell with `bin/hubot`
 
 ### Publishing

--- a/Rakefile
+++ b/Rakefile
@@ -26,12 +26,12 @@ desc "Build Docker image"
 task 'docker:build' do
   system("docker build --no-cache=true -t puppetlabs/bunsen:#{version} -t puppetlabs/bunsen:latest .")
   puts 'Start container manually with: docker run -it puppetlabs/bunsen'
-  puts 'Or rake docker::run'
+  puts 'Or rake docker:run'
 end
 
 desc "Run Bunsen image locally for debugging"
-task 'docker::run' do
-  `docker run -it puppetlabs/bunsen`
+task 'docker:run' do
+  `docker run --env-file env.dev -it puppetlabs/bunsen`
 end
 
 desc "Upload image to GCE"


### PR DESCRIPTION
This doesn't help the fact that you have to go generate all the tokens
and whatnot, so I don't know if it actually helps many contributors test
their fixes yet. I'll see if I can make those optional at some point.
